### PR TITLE
Fix token as 'type'=>'string'

### DIFF
--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -14,7 +14,7 @@ class File extends \atk4\data\Model {
     {
         parent::init();
 
-        $this->addField('token', ['system'=>true]);
+        $this->addField('token', ['system'=>true, 'type' => 'string']);
         $this->addField('location');
         $this->addField('url');
         $this->addField('storage');


### PR DESCRIPTION
in recent PR was removed the type => string for File token.
Using atk4/schema type => string with system => true is treated as integer, i think this is a bug in atk4/data