### PR TITLE
fix demo and Helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "homepage": "https://github.com/atk4/filestore",
     "require": {
         "php": ">=7.4 <8.3",
-        "atk4/ui": "dev-develop",
+        "atk4/ui": "dev-feature/support-stream-in-terminate",
         "league/flysystem": "^2.0"
     },
     "require-release": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-release": {
         "php": ">=7.4 <8.3",
-        "atk4/ui": "~4.0.0",
+        "atk4/ui": "~5.0.0",
         "league/flysystem": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "homepage": "https://github.com/atk4/filestore",
     "require": {
         "php": ">=7.4 <8.3",
-        "atk4/ui": "dev-feature/support-stream-in-terminate",
+        "atk4/ui": "dev-develop",
         "league/flysystem": "^2.0"
     },
     "require-release": {

--- a/demos/_demo-data/create-db.php
+++ b/demos/_demo-data/create-db.php
@@ -26,6 +26,7 @@ $fileModel->addField('url', ['type' => 'text']);
 $fileModel->addField('storage');
 $fileModel->addField('status');
 $fileModel->addField('source_file_id', ['type' => 'integer']);
+$fileModel->addField('created_at', ['type' => 'datetime', 'required' => true]);
 $fileModel->addField('meta_filename');
 $fileModel->addField('meta_extension');
 $fileModel->addField('meta_md5');

--- a/demos/index.php
+++ b/demos/index.php
@@ -10,6 +10,8 @@ use Atk4\Filestore\Model\File;
 use Atk4\Ui\Callback;
 use Atk4\Ui\Columns;
 use Atk4\Ui\Form;
+use Atk4\Ui\Header;
+use Atk4\Ui\Js\JsBlock;
 use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\View;
 use League\Flysystem\Filesystem;
@@ -36,34 +38,42 @@ $filesystem = new Filesystem($adapter);
 
 $col = Columns::addTo($app);
 
-$form = Form::addTo($col->addColumn());
+// New friend form
+$c1 = $col->addColumn()->setStyle('border', '1px solid gray');
+
+Header::addTo($c1, ['Add New Friend']);
+$form = Form::addTo($c1);
 $form->setModel(
     (new Friend($app->db, [
         'filesystem' => $filesystem,
     ]))->createEntity()
 );
+$form->onSubmit(function (Form $form) use ($app) {
+    $form->model->save();
 
-$gr = \Atk4\Ui\Grid::addTo($col->addColumn(), [
+    return new JsBlock([
+        $app->layout->jsReload(),
+    ]);
+});
+
+// Grid with all filestore files
+$c2 = $col->addColumn()->setStyle('border', '1px solid gray');
+
+Header::addTo($c2, ['All Filestore Files']);
+$gr = \Atk4\Ui\Grid::addTo($c2, [
     'menu' => false,
     'paginator' => false,
 ]);
 $gr->setModel(new File($app->db));
 
-$form->onSubmit(function (Form $form) use ($gr) {
-    $form->model->save();
-
-    return [
-        $gr->jsReload(),
-    ];
-});
-
 View::addTo($app, ['ui' => 'divider']);
 
+// CRUD with all Friends records
+Header::addTo($app, ['All Friends']);
 $crud = \Atk4\Ui\Crud::addTo($app);
 $crud->setModel(new Friend($app->db, ['filesystem' => $filesystem]));
 
-View::addTo($app, ['ui' => 'divider']);
-
+// custom actions
 $callbackDownload = Callback::addTo($app);
 $callbackDownload->set(function () use ($crud) {
     $id = $crud->getApp()->stickyGet('row_id');

--- a/demos/index.php
+++ b/demos/index.php
@@ -61,7 +61,7 @@ Header::addTo($c2, ['All Filestore Files']);
 $gr = \Atk4\Ui\Crud::addTo($c2, [
     'paginator' => false,
 ]);
-$files = new File($app->db);
+$files = new File($app->db, ['flysystem' => $filesystem]);
 $files->removeUserAction('add');
 $files->removeUserAction('edit');
 $files->removeUserAction('delete');

--- a/demos/index.php
+++ b/demos/index.php
@@ -62,17 +62,16 @@ $c2 = $col->addColumn()->setStyle('border', '1px solid gray');
 
 Header::addTo($c2, ['All Filestore Files']);
 $gr = \Atk4\Ui\Crud::addTo($c2, [
-    //'menu' => false,
     'paginator' => false,
 ]);
 $files = new File($app->db);
 $files->removeUserAction('add');
 $files->removeUserAction('edit');
 $files->addUserAction('cleanup_drafts', [
-    'callback' => function($m) use ($gr) {
+    'callback' => function($m) {
         $m->cleanupDrafts();
-        //return $gr->jsReload(); // @todo this way it's impossible
         return 'Draft files are deleted.';
+        // return $gr->jsReload(); // @todo this way it's impossible
     },
     'appliesTo' => Model\UserAction::APPLIES_TO_NO_RECORDS,
     'description' => 'Cleanup Drafts',

--- a/demos/index.php
+++ b/demos/index.php
@@ -68,8 +68,9 @@ $files = new File($app->db);
 $files->removeUserAction('add');
 $files->removeUserAction('edit');
 $files->addUserAction('cleanup_drafts', [
-    'callback' => function($m) {
+    'callback' => function ($m) {
         $m->cleanupDrafts();
+
         return 'Draft files are deleted.';
         // return $gr->jsReload(); // @todo this way it's impossible
     },

--- a/demos/index.php
+++ b/demos/index.php
@@ -52,9 +52,7 @@ $form->setModel(
 $form->onSubmit(function (Form $form) use ($app) {
     $form->model->save();
 
-    return new JsBlock([
-        $app->layout->jsReload(),
-    ]);
+    return $app->layout->jsReload();
 });
 
 // Grid with all filestore files

--- a/demos/index.php
+++ b/demos/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atk4\Filestore\Demos;
 
+use Atk4\Data\Model;
 use Atk4\Data\Persistence;
 use Atk4\Filestore\Helper;
 use Atk4\Filestore\Model\File;
@@ -60,11 +61,23 @@ $form->onSubmit(function (Form $form) use ($app) {
 $c2 = $col->addColumn()->setStyle('border', '1px solid gray');
 
 Header::addTo($c2, ['All Filestore Files']);
-$gr = \Atk4\Ui\Grid::addTo($c2, [
-    'menu' => false,
+$gr = \Atk4\Ui\Crud::addTo($c2, [
+    //'menu' => false,
     'paginator' => false,
 ]);
-$gr->setModel(new File($app->db));
+$files = new File($app->db);
+$files->removeUserAction('add');
+$files->removeUserAction('edit');
+$files->addUserAction('cleanup_drafts', [
+    'callback' => function($m) use ($gr) {
+        $m->cleanupDrafts();
+        //return $gr->jsReload(); // @todo this way it's impossible
+        return 'Draft files are deleted.';
+    },
+    'appliesTo' => Model\UserAction::APPLIES_TO_NO_RECORDS,
+    'description' => 'Cleanup Drafts',
+]);
+$gr->setModel($files);
 
 View::addTo($app, ['ui' => 'divider']);
 

--- a/demos/index.php
+++ b/demos/index.php
@@ -67,6 +67,7 @@ $gr = \Atk4\Ui\Crud::addTo($c2, [
 $files = new File($app->db);
 $files->removeUserAction('add');
 $files->removeUserAction('edit');
+$files->removeUserAction('delete');
 $files->addUserAction('cleanup_drafts', [
     'callback' => function ($m) {
         $m->cleanupDrafts();

--- a/demos/index.php
+++ b/demos/index.php
@@ -12,7 +12,6 @@ use Atk4\Ui\Callback;
 use Atk4\Ui\Columns;
 use Atk4\Ui\Form;
 use Atk4\Ui\Header;
-use Atk4\Ui\Js\JsBlock;
 use Atk4\Ui\Js\JsExpression;
 use Atk4\Ui\View;
 use League\Flysystem\Filesystem;
@@ -71,7 +70,7 @@ $files->addUserAction('cleanup_drafts', [
         $m->cleanupDrafts();
 
         return 'Draft files are deleted.';
-        // return $gr->jsReload(); // @todo this way it's impossible
+        // return $gr->jsReload(); // @todo this way it's impossible?
     },
     'appliesTo' => Model\UserAction::APPLIES_TO_NO_RECORDS,
     'description' => 'Cleanup Drafts',

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -67,7 +67,7 @@ class Upload extends \Atk4\Ui\Form\Control\Upload
         $model = $this->entityField->getField()->fileModel;
         $entity = $model->loadBy('token', $token);
 
-        if ($entity->get('status') === 'draft') {
+        if ($entity->get('status') === $entity::STATUS_DRAFT) {
             $entity->delete();
         }
 

--- a/src/Form/Control/Upload.php
+++ b/src/Form/Control/Upload.php
@@ -29,34 +29,8 @@ class Upload extends \Atk4\Ui\Form\Control\Upload
     {
         // provision a new file for specified flysystem
         $model = $this->entityField->getField()->fileModel;
-        $entity = $model->newFile();
+        $entity = $model->createFromPath($file['tmp_name'], $file['name']);
 
-        // add (or upload) the file
-        $stream = fopen($file['tmp_name'], 'r+');
-        $this->entityField->getField()->flysystem->writeStream($entity->get('location'), $stream, ['visibility' => 'public']);
-        if (is_resource($stream)) {
-            fclose($stream);
-        }
-
-        $detector = new \League\MimeTypeDetection\FinfoMimeTypeDetector();
-
-        $mimeType = $detector->detectMimeTypeFromFile($file['tmp_name']);
-        // get meta from browser
-        $entity->set('meta_mime_type', $mimeType);
-
-        // store meta-information
-        $imageSizeArr = getimagesize($file['tmp_name']);
-        $entity->set('meta_is_image', $imageSizeArr !== false);
-        if ($imageSizeArr !== false) {
-            $entity->set('meta_image_width', $imageSizeArr[0]);
-            $entity->set('meta_image_height', $imageSizeArr[1]);
-        }
-
-        $entity->set('meta_md5', md5_file($file['tmp_name']));
-        $entity->set('meta_filename', $file['name']);
-        $entity->set('meta_size', $file['size']);
-
-        $entity->save();
         $this->setFileId($entity->get('token'));
 
         return null;

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -53,14 +53,9 @@ class Helper
 
         if ($streamOutput) {
             $resource = $model->flysystem->readStream($path);
-            $stream = Stream::create($resource);
-            $app->getResponse()->withBody($stream);
-
-            // @todo
-            // 1. in App->outputResponse it overwrites stream?
-            // 2. in same method i guess we have to add if ($this->response->getBody()->isWritable()) for write()
-            // 3. but also that do not help - it still streams empty response for some reason even if in stream there is data
-            $app->terminate();
+            $factory = new \Nyholm\Psr7\Factory\Psr17Factory();
+            $stream = $factory->createStreamFromResource($resource);
+            $app->terminate($stream);
         } else {
             $app->terminate($model->flysystem->read($path));
         }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -6,7 +6,7 @@ namespace Atk4\Filestore;
 
 use Atk4\Filestore\Model\File;
 use Atk4\Ui\App;
-use Nyholm\Psr7\Stream;
+use Nyholm\Psr7\Factory\Psr17Factory
 
 class Helper
 {
@@ -53,7 +53,7 @@ class Helper
 
         if ($streamOutput) {
             $resource = $model->flysystem->readStream($path);
-            $factory = new \Nyholm\Psr7\Factory\Psr17Factory();
+            $factory = new Psr17Factory();
             $stream = $factory->createStreamFromResource($resource);
             $app->terminate($stream);
         } else {

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -6,7 +6,7 @@ namespace Atk4\Filestore;
 
 use Atk4\Filestore\Model\File;
 use Atk4\Ui\App;
-use Nyholm\Psr7\Factory\Psr17Factory
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 class Helper
 {
@@ -24,7 +24,7 @@ class Helper
         $app->setResponseHeader('Pragma', 'public');
         $app->setResponseHeader('Accept-Ranges', 'bytes');
 
-        static::output($model, $app, true);
+        static::output($model, $app);
     }
 
     /**
@@ -41,23 +41,18 @@ class Helper
         $app->setResponseHeader('Pragma', 'public');
         $app->setResponseHeader('Accept-Ranges', 'bytes');
 
-        static::output($model, $app, true);
+        static::output($model, $app);
     }
 
     /**
      * @return never
      */
-    protected static function output(File $model, App $app, bool $streamOutput = false): void
+    protected static function output(File $model, App $app): void
     {
         $path = $model->get('location');
-
-        if ($streamOutput) {
-            $resource = $model->flysystem->readStream($path);
-            $factory = new Psr17Factory();
-            $stream = $factory->createStreamFromResource($resource);
-            $app->terminate($stream);
-        } else {
-            $app->terminate($model->flysystem->read($path));
-        }
+        $resource = $model->flysystem->readStream($path);
+        $factory = new Psr17Factory();
+        $stream = $factory->createStreamFromResource($resource);
+        $app->terminate($stream);
     }
 }

--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -78,7 +78,7 @@ class File extends Model
 
         // change status of thumbs when status of original image changes
         $this->onHook(Model::HOOK_AFTER_SAVE, function (self $m) {
-            if ($m->get('status')===self::STATUS_LINKED) {
+            if ($m->get('status') === self::STATUS_LINKED) {
                 $files = (clone $m->getModel())->addCondition('source_file_id', $m->getId());
                 foreach ($files as $file) {
                     $file->set('status', self::STATUS_THUMB);
@@ -186,17 +186,20 @@ class File extends Model
         $max_width = $this->thumbnailMaxWidth;
         $max_height = $this->thumbnailMaxHeight;
 
-        list($width, $height, $image_type) = getimagesize($path);
+        [$width, $height, $image_type] = getimagesize($path);
 
         switch ($image_type) {
             case \IMAGETYPE_GIF:
                 $src = imagecreatefromgif($path);
+
                 break;
             case \IMAGETYPE_JPEG:
                 $src = imagecreatefromjpeg($path);
+
                 break;
             case \IMAGETYPE_PNG:
                 $src = imagecreatefrompng($path);
+
                 break;
             default:
                 return false; // unsupported image type
@@ -219,7 +222,7 @@ class File extends Model
         $tmp = imagecreatetruecolor($tn_width, $tn_height);
 
         // Check if this image is PNG or GIF, then set if Transparent
-        if ($image_type == \IMAGETYPE_PNG || $image_type == \IMAGETYPE_GIF) {
+        if ($image_type === \IMAGETYPE_PNG || $image_type === \IMAGETYPE_GIF) {
             imagealphablending($tmp, false);
             imagesavealpha($tmp, true);
             $transparent = imagecolorallocatealpha($tmp, 255, 255, 255, 127);
@@ -232,12 +235,15 @@ class File extends Model
         switch ($image_type) {
             case \IMAGETYPE_GIF:
                 imagegif($tmp, $thumbFile);
+
                 break;
             case \IMAGETYPE_JPEG:
                 imagejpeg($tmp, $thumbFile, 100); // best quality
+
                 break;
             case \IMAGETYPE_PNG:
                 imagepng($tmp, $thumbFile, 0); // no compression
+
                 break;
         }
         $uri = stream_get_meta_data($thumbFile)['uri'];

--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -104,7 +104,10 @@ class File extends Model
         });
     }
 
-    public function newFile(): Model
+    /**
+     * @return $this
+     */
+    public function newFile()
     {
         $this->assertIsModel();
 
@@ -120,8 +123,10 @@ class File extends Model
      *
      * @param string $path     Path to file to import
      * @param string $fileName Optional original file name
+     *
+     * @return $this
      */
-    public function createFromPath(string $path, string $fileName = null): Model
+    public function createFromPath(string $path, string $fileName = null)
     {
         $this->assertIsModel();
 

--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -105,7 +105,7 @@ class File extends Model
     }
 
     /**
-     * @return $this
+     * @return static
      */
     public function newFile()
     {
@@ -124,7 +124,7 @@ class File extends Model
      * @param string $path     Path to file to import
      * @param string $fileName Optional original file name
      *
-     * @return $this
+     * @return static
      */
     public function createFromPath(string $path, string $fileName = null)
     {

--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -13,6 +13,28 @@ class File extends Model
 
     public ?string $titleField = 'meta_filename';
 
+    /** @const string */
+    public const STATUS_DRAFT = 'draft';
+    /** @const string Not implemented */
+    public const STATUS_UPLOADED = 'uploaded';
+    /** @const string Not implemented */
+    public const STATUS_THUMB_OK = 'thumbok';
+    /** @const string Not implemented */
+    public const STATUS_NORMAL_OK = 'normalok';
+    /** @const string Not implemented */
+    public const STATUS_READY = 'ready';
+    /** @const string Not implemented */
+    public const STATUS_LINKED = 'linked';
+    /** @const array */
+    public const ALL_STATUSES = [
+        self::STATUS_DRAFT,
+        self::STATUS_UPLOADED,
+        self::STATUS_THUMB_OK,
+        self::STATUS_NORMAL_OK,
+        self::STATUS_READY,
+        self::STATUS_LINKED,
+    ];
+
     /** @var Filesystem */
     public $flysystem;
 
@@ -39,8 +61,8 @@ class File extends Model
         ]);
 
         $this->addField('status', [
-            'enum' => ['draft', 'uploaded', 'thumbok', 'normalok', 'ready', 'linked'],
-            'default' => 'draft',
+            'enum' => self::ALL_STATUSES,
+            'default' => self::STATUS_DRAFT,
         ]);
 
         $this->addField('meta_filename');

--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -16,22 +16,22 @@ class File extends Model
     /** @const string All uploaded files first get this status */
     public const STATUS_DRAFT = 'draft';
     /** @const string Not implemented */
-    //public const STATUS_UPLOADED = 'uploaded';
+    // public const STATUS_UPLOADED = 'uploaded';
     /** @const string Not implemented */
-    //public const STATUS_THUMB_OK = 'thumbok';
+    // public const STATUS_THUMB_OK = 'thumbok';
     /** @const string Not implemented */
-    //public const STATUS_NORMAL_OK = 'normalok';
+    // public const STATUS_NORMAL_OK = 'normalok';
     /** @const string Not implemented */
-    //public const STATUS_READY = 'ready';
+    // public const STATUS_READY = 'ready';
     /** @const string When file is linked to some other model */
     public const STATUS_LINKED = 'linked';
     /** @const array */
     public const ALL_STATUSES = [
         self::STATUS_DRAFT,
-        //self::STATUS_UPLOADED,
-        //self::STATUS_THUMB_OK,
-        //self::STATUS_NORMAL_OK,
-        //self::STATUS_READY,
+        // self::STATUS_UPLOADED,
+        // self::STATUS_THUMB_OK,
+        // self::STATUS_NORMAL_OK,
+        // self::STATUS_READY,
         self::STATUS_LINKED,
     ];
 
@@ -112,8 +112,7 @@ class File extends Model
     {
         $files = (clone $this->getModel())
             ->addCondition('status', self::STATUS_DRAFT)
-            ->addCondition('created_at', '<', (new \DateTime())->sub(new \DateInterval('PT' . $this->cleanupDraftsDelay . 'S')))
-            ;
+            ->addCondition('created_at', '<', (new \DateTime())->sub(new \DateInterval('PT' . $this->cleanupDraftsDelay . 'S')));
         foreach ($files as $file) {
             $file->delete();
         }


### PR DESCRIPTION
* adds `cleanupDrafts` method in `File` data model
* fixes `linked` status implementation
* delete filesystem file only **after** we actually delete file record in DB. That's important for safety to not break data integrity in case DB statement fails for some reason. It's not that bad if we have orphaned filesystem file, but having orphaned DB record is not acceptable.
* fix and improve demo