### PR TITLE
Fix hasOne type mismatch for FileField

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
     ],
     "homepage": "https://github.com/atk4/filestore",
     "require": {
-        "php": ">=7.4 <8.3",
+        "php": ">=7.4 <8.4",
         "atk4/ui": "dev-develop",
         "league/flysystem": "^2.0"
     },
     "require-release": {
-        "php": ">=7.4 <8.3",
+        "php": ">=7.4 <8.4",
         "atk4/ui": "~5.0.0",
         "league/flysystem": "^2.0"
     },

--- a/demos/index.php
+++ b/demos/index.php
@@ -49,7 +49,7 @@ $form->setModel(
     ]))->createEntity()
 );
 
-$form->onSubmit(function (Form $form) use ($app) {
+$form->onSubmit(static function (Form $form) use ($app) {
     $form->model->save();
 
     return $app->layout->jsReload();
@@ -62,7 +62,7 @@ $gr = Grid::addTo($c2, [
     'paginator' => false,
 ]);
 $files = new File($app->db, ['flysystem' => $filesystem]);
-$gr->menu->addItem('Cleanup Drafts')->on('click', function () use ($gr, $files) {
+$gr->menu->addItem('Cleanup Drafts')->on('click', static function () use ($gr, $files) {
     $files->cleanupDrafts();
 
     return $gr->jsReload();
@@ -78,7 +78,7 @@ $crud->setModel(new Friend($app->db, ['filesystem' => $filesystem]));
 
 // custom actions
 $callbackDownload = Callback::addTo($app);
-$callbackDownload->set(function () use ($crud) {
+$callbackDownload->set(static function () use ($crud) {
     $id = $crud->getApp()->stickyGet('row_id');
     $model = (clone $crud->model);
     $model_file = File::assertInstanceOf($model->load($id)->ref('file'));
@@ -94,7 +94,7 @@ $crud->addActionButton(
 );
 
 $callbackView = Callback::addTo($app);
-$callbackView->set(function () use ($crud) {
+$callbackView->set(static function () use ($crud) {
     $id = $crud->getApp()->stickyGet('row_id');
     $model = (clone $crud->model);
     $model_file = File::assertInstanceOf($model->load($id)->ref('file'));

--- a/src/Field/FileField.php
+++ b/src/Field/FileField.php
@@ -43,6 +43,7 @@ class FileField extends Field
         }
 
         $this->reference = HasOneSql::assertInstanceOf($this->getOwner()->hasOne($this->shortName, [
+            'type' => $this->fileModel->getField('token')->type,
             'model' => $this->fileModel,
             'theirField' => 'token',
         ]));

--- a/src/Field/FileField.php
+++ b/src/Field/FileField.php
@@ -43,7 +43,7 @@ class FileField extends Field
         }
 
         $this->reference = HasOneSql::assertInstanceOf($this->getOwner()->hasOne($this->shortName, [
-            'type' => $this->fileModel->getField('token')->type,
+            'type' => $this->fileModel->getField('token')->type, // TODO imply in https://github.com/atk4/data/blob/develop/src/Reference/HasOne.php#L27
             'model' => $this->fileModel,
             'theirField' => 'token',
         ]));


### PR DESCRIPTION
Fix hasOne type mismatch error for FileField ensuring same type for both parent `token` and child fields  