### PR TITLE
Check existing location tokens on unconditioned model

### DIFF
--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -108,7 +108,7 @@ class File extends Model
         $this->onHookShort(Model::HOOK_AFTER_DELETE, function () {
             $path = $this->get('location');
             if ($path && $this->flysystem->fileExists($path)) {
-                $files = (clone $this->getModel())->addCondition(
+                $files = (new self($this->getModel()->getPersistence()))->addCondition(
                     'id',
                     '!=',
                     $this->getId()


### PR DESCRIPTION
File model can have other restrictions, such as `status=draft` or `is_deleted=true`. In this case other existing file links cannot be found, and therefore the physical file is deleted, even though records exist with `status=linked` or `is_deleted=false`